### PR TITLE
Run github jobs using a docker-compose setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,134 +18,95 @@ on: push
 # New opportunities:
 # - run tests on mac (GitHub provides MacOS runners)
 # - standardize WSL tasks by using GitHub-provided runners
-
+#
+#
+# NOTE:
+#
+# * GitHub Actions do not support YAML variables and/or YAML anchors, which
+#   leads to some repetition. Job matrices solve this to some extent but
+#   combined with some other issues, this seems like a ongoing source of
+#   misery.
+# * Not being able to use the standard `container` directive for running our
+#   tests is one such example that makes this situation seem worse.
+#
+# * We have caches etc in GitHub Actions as well, so I don't think we are
+#   missing any killer feature.
+#
+# * Fixing most of the to-do items is mostly mostly a matter of adding more
+#   configuration.
+# * Some of these tasks can probably live in a different yaml file as a
+#   separate workflow.
+#
+# * Similar to GitLab, GitHub also has a container registry, so we can move our
+#   testsuite images there if/when we want to fully migrate off of GitLab.
 env:
-  CI_IMAGE: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:30-master-154893333
-  PYTEST_ARGS: --color=yes --integration -n 4
+  DOCKER_BUILDKIT: 1
+  COMPOSE_DOCKER_CLI_BUILD: 1
 
 jobs:
   tests:
     runs-on: ubuntu-20.04
     continue-on-error: ${{ matrix.allow-failure || false }}
-
-    env:
-      CI_IMAGE_PREFIX: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite
-      CI_IMAGE_SUFFIX: master-154893333
-      TOXENV: py36,py6-plugins,py37,py37-plugins,py38,py38-plugins
-      # FIXME: De-duplicate against tox.ini
-      BST_PLUGINS_EXPERIMENTAL_VERSION: 1.93.4
-
     strategy:
       fail-fast: false
       matrix:
-
-        # Main test targets, the name defines the image that will be used as
-        # the base for running tests.
-        test-name:
+        platform:
           - debian:10
           - fedora:30
           - fedora:31
           - ubuntu:18.04
           - centos:7.7.1908
-
+        test_cmd:
+          - tox -- --color=yes --integration -n 4
+        toxenv:
+          - py36-nocover,py37-nocover,py38-nocover
+        bst-plugins-experimental-version:
+          - 1.93.4
+        allow-failure:
+          - false
         include:
+          - platform: fedora:30
+            test_cmd: tox -e mypy
+          - platform: fedora:30
+            test_cmd: tox -e format-check,lint
+          - platform: fedora:30
+            test_cmd: tox -e docs
+            # This appears to require this env being set
+            bst-plugins-experimental-version: 1.93.4
           # Ensure that tests also pass without `--develop` flag.
           - test-name: no-usedevelop
-            image-name: fedora:31
+            platform: fedora:31
             toxenv: py36-nocover,py37-nocover,py38-nocover
-
           # Test the master version of some external plugins
           - test-name: plugins-master
-            image-name: fedora:31
+            platform: fedora:31
             bst-plugins-experimental-version: master
             allow-failure: true
-
+    env:
+      PLATFORM: ${{ matrix.platform }}
+      TEST_CMD: ${{ matrix.test_cmd }}
+      TOX_ENV: ${{ matrix.toxenv }}
+      BST_PLUGINS_EXPERIMENTAL_VERSION: ${{ matrix.bst-plugins-experimental-version }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
         # BuildStream requires tags to be able to find its version.
         with:
           fetch-depth: 0
-      # XXX: Our run command looks like a monstrosity because we need to
-      # specify `--device /dev/fuse` and there's no way to do that using the
-      # `container` directive directly.
-      # This is also why we have forward environment variables by hand.
-      # TODO: In future, we should find a way to simplify this. See some
-      # relevant discussion at:
-      # https://github.community/t/how-to-run-privileged-docker-container/16431.
-      # XXX: Value of `volume` and `workdir` must match how GitHub
-      # Actions sets up paths.
-      # TODO: Have test user pre-created in the test image.
-      - name: Run tox inside a container
+      - name: run tests
         run: |
-          docker run \
-              --privileged \
-              --device /dev/fuse \
-              --env PYTEST_ARGS \
-              --env TOXENV=${{ matrix.toxenv || env.TOXENV }} \
-              --env BST_PLUGINS_EXPERIMENTAL_VERSION=${{ matrix.bst-plugins-experimental-version || env.BST_PLUGINS_EXPERIMENTAL_VERSION }} \
-              --volume /home/runner/work:/__w \
-              --workdir /__w/buildstream/buildstream \
-              "$CI_IMAGE_PREFIX"-${{ matrix.image-name || matrix.test-name }}-"$CI_IMAGE_SUFFIX" \
-              bash -c 'useradd -Um buildstream && chown -R buildstream:buildstream . && su buildstream -c "tox -- $PYTEST_ARGS"'
-
+          docker-compose up --exit-code-from tests tests
   tests-fedora-missing-deps:
     runs-on: ubuntu-20.04
-    container: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:30-master-154893333
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-        # BuildStream requires tags to be able to find its version.
-        with:
-          fetch-depth: 0
-      - name: Uninstall Bubblewrap and OSTree
-        # We remove the Bubblewrap and OSTree packages here so that we catch any
-        # codepaths that try to use them. Removing OSTree causes fuse-libs to
-        # disappear unless we mark it as user-installed.
-        run: |
-          dnf mark install fuse-libs systemd-udev
-          dnf erase -y bubblewrap ostree
-      - name: Add test user
-        run: |
-          useradd -Um buildstream
-          chown -R buildstream:buildstream .
-      - name: Run tests
-        run: su buildstream -c "tox -- $PYTEST_ARGS"
-
-  mypy:
-    runs-on: ubuntu-20.04
-    container: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:30-master-154893333
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Run tox inside a container
-        run: tox -e mypy
-
-  lint:
-    runs-on: ubuntu-20.04
-    container: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:30-master-154893333
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Run tox inside a container
-        run: tox -e format-check,lint
-
-  docs:
-    runs-on: ubuntu-20.04
     env:
-      BST_FORCE_SESSION_REBUILD: 1
+      PLATFORM: fedora:31
+      TEST_CMD: tox -- --color=yes --integration -n 4
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
         # BuildStream requires tags to be able to find its version.
         with:
           fetch-depth: 0
-      - name: Run tox inside a container
+      - name: run tests
         run: |
-          docker run \
-              --privileged \
-              --device /dev/fuse \
-              --volume /home/runner/work:/__w \
-              --workdir /__w/buildstream/buildstream \
-              $CI_IMAGE \
-              tox -e docs
+          docker-compose up --exit-code-from fedora_missing_deps fedora_missing_deps

--- a/.github/workflows/overnight.yml
+++ b/.github/workflows/overnight.yml
@@ -1,0 +1,23 @@
+name: overnight
+on: 
+  schedule:
+    - cron: '0 4 * * *'
+
+env:
+  DOCKER_BUILDKIT: 1
+  COMPOSE_DOCKER_CLI_BUILD: 1
+
+jobs:
+  overnight:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        # BuildStream requires tags to be able to find its version.
+        with:
+          fetch-depth: 0
+      - name: run tests
+        run: |
+          docker-compose up --exit-code-from no_cache no_cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,71 @@
+ARG DOCKER_IMAGE_VERSION
+ARG PLATFORM
+FROM registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-$PLATFORM-$DOCKER_IMAGE_VERSION AS base
+
+##
+# Docker stages for building test containers
+##
+FROM base as test_setup
+
+ADD . /buildstream
+WORKDIR /buildstream
+RUN useradd -Um buildstream
+RUN chown -R buildstream:buildstream .
+
+ENTRYPOINT ["su", "buildstream", "-c"]
+
+FROM test_setup as randomised_tests
+
+ARG INTEGRATION_CACHE
+RUN mkdir -p ${INTEGRATION_CACHE}
+
+ENTRYPOINT ["su", "buildstream", "-c"]
+
+FROM test_setup as fedora_missing_deps
+
+RUN dnf mark install fuse-libs systemd-udev
+RUN dnf erase -y bubblewrap ostree
+
+ENTRYPOINT ["su", "buildstream", "-c"]
+
+##
+# Docker stages for building integration overnight tests
+##
+FROM base as build_env
+
+ARG BST_EXT_REF
+ARG FD_SDK_REF
+
+RUN mkdir -p "${HOME}/.config"
+RUN { \
+    echo "scheduler:"; \
+    echo "  fetchers: 2"; \
+}  >  "${HOME}/.config/buildstream.conf"
+RUN dnf install -y ostree
+
+ADD . /buildstream
+WORKDIR /buildstream
+RUN pip3 install \
+      -r requirements/requirements.txt \
+      . \
+      git+https://gitlab.com/buildstream/bst-plugins-experimental.git@${BST_EXT_REF}#egg=bst_plugins_experimental[cargo]
+RUN git clone https://gitlab.com/freedesktop-sdk/freedesktop-sdk.git
+RUN git -C freedesktop-sdk checkout ${FD_SDK_REF}
+
+FROM build_env as cache_setup
+RUN { \
+    echo "# Get a lot of output in case of errors"; \
+    echo "logging:"; \
+    echo "  error-lines: 80"; \
+    echo "#"; \
+    echo "# Artifacts"; \
+    echo "#"; \
+    echo "artifacts:"; \
+    echo "- url: https://cache-test.buildstream.build:11002"; \
+    echo "  client-cert: $OVERNIGHT_CACHE_PUSH_CERT"; \ 
+    echo "  client-key: $OVERNIGHT_CACHE_PUSH_KEY"; \
+    echo "  push: true"; \
+} > ~/.config/buildstream.conf
+
+FROM build_env as no_cache_setup
+RUN sed -i '/artifacts:/,+1 d' freedesktop-sdk/project.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.4'
+x-base-platform-template: &base-platform
+    privileged: true
+    devices:
+    - /dev/fuse:/dev/fuse
+
+services:
+  tests:
+    <<: *base-platform
+    build:
+      context: .
+      target: test_setup
+      args:
+        PLATFORM: $PLATFORM
+        DOCKER_IMAGE_VERSION: master-154893333
+    environment:
+      - TOX_ENV=$TOX_ENV
+      - BST_PLUGINS_EXPERIMENTAL_VERSION=$BST_PLUGINS_EXPERIMENTAL_VERSION
+    command: >
+      '${TEST_CMD}'
+  fedora_missing_deps:
+    <<: *base-platform
+    build:
+      context: .
+      target: fedora_missing_deps
+      args:
+        PLATFORM: fedora:31
+        DOCKER_IMAGE_VERSION: master-154893333
+    command: >
+      '${TEST_CMD}'
+  no_cache:
+    <<: *base-platform
+    build:
+      context: .
+      target: no_cache_setup
+      args:
+        PLATFORM: fedora:31
+        BST_EXT_REF: 1.93.4
+        FD_SDK_REF: freedesktop-sdk-20.08beta.1-buildstream2
+        DOCKER_IMAGE_VERSION: master-154893333
+    command: >
+      make -C freedesktop-sdk


### PR DESCRIPTION
** THIS IS REPLICATED FROM https://github.com/cs-shadow/buildstream/pull/143 **


Currently in github/gitlab we add build dependencies and/or
provide runtime configuration of the containers themselves
within the github/gitlab yaml definitions. As github actions
has far less support for templating/anchors, this results
in a significant amount of duplication.

Therefore, split runtime configuration of containers to
a docker-compose file, and build time configuration via
a Dockerfile. This then frees the github workflow to define
the remaining top level parameters via a matrix.