### PR TITLE
Create docs artifacts and publish them in releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
           docker run \
               --privileged \
               --device /dev/fuse \
+              --env BST_FORCE_SESSION_REBUILD \
               --volume /home/runner/work:/__w \
               --workdir /__w/buildstream/buildstream \
               $CI_IMAGE \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,3 +170,10 @@ jobs:
               --workdir /__w/buildstream/buildstream \
               $CI_IMAGE \
               tox -e docs
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: docs
+          path: doc/build/html
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Upload Release Asset
+
+env:
+  CI_IMAGE: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:32-master-177137613
+  BST_FORCE_SESSION_REBUILD: 1
+
+on:
+  push:
+    tags:
+    - '*.*.*'
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        # BuildStream requires tags to be able to find its version.
+        with:
+          fetch-depth: 0
+
+      - name: Build documentation
+        run: |
+          docker run \
+              --privileged \
+              --device /dev/fuse \
+              --env BST_FORCE_SESSION_REBUILD \
+              --volume /home/runner/work:/__w \
+              --workdir /__w/buildstream/buildstream \
+              $CI_IMAGE \
+              tox -e docs
+          tar -C doc/build/html -zcf docs.tgz .
+
+      - name: Upload release assets
+        run: |
+          tag_name="${GITHUB_REF##*/}"
+          hub release create -a "docs.tgz" -m "$tag_name" "$tag_name"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR does the following:

* Include's @ChrisPolin's commit which uploads a workflow artifact of the docs build
  * This allows us to download the built docs from a CI job and browse it locally, so we can review docs changes pre-merge
* Fixes the docs build to ensure that the session files are really rebuilt
* Adds `.github/workflow/release.yml`
  * This workflow is triggered anytime there is a release pattern matching tag pushed to the repository
  * This workflow will *also* build the docs
  * This workflow will create a new release on github, using `hub release create`
  * The built documentation will be uploaded as an attached *"release asset"* to the release
  * The github `hub release create` command will automatically take care of preparing a zip file and a tarball for the release
