### PR TITLE
.github/workflows/ci.yml: Add radon analysis job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,3 +178,36 @@ jobs:
           name: docs
           path: doc/build/html
 
+  analysis:
+    runs-on: ubuntu-20.04
+    container: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:10-master-177137613
+    needs: tests
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        # BuildStream requires tags to be able to find its version.
+        with:
+          fetch-depth: 0
+      - name: radon
+        run: |
+          # Workaround radon issue not requiring it's dependency
+          pip3 install flake8_polyfill
+          pip3 install radon
+          mkdir analysis
+
+          echo "Calculating Maintainability Index"
+          radon mi -s -j src/buildstream > analysis/mi.json
+          radon mi -s src/buildstream
+
+          echo "Calculating Cyclomatic Complexity"
+          radon cc -a -s -j src/buildstream > analysis/cc.json
+          radon cc -a -s src/buildstream
+
+          echo "Calculating Raw Metrics"
+          radon raw -s -j src/buildstream > analysis/raw.json
+          radon raw -s src/buildstream
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: analysis
+          path: analysis/


### PR DESCRIPTION
Analysis & artifact creation only happens if `tests` job passes,
this is somewhat representative of the default `post` stage in
gitlab-ci

We could explicitly match gitlab-ci & `need` all tests (not just the bst fucntionality tests) to have passed (lint, mypy etc), however for this job specifically I think there's value in the radon reports even if there's a small lint/style error.