### PR TITLE
Add coverage.py & initial Codecov integration into Github CI

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,28 @@
+# https://docs.codecov.io/docs/codecovyml-reference
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,8 @@ on:
   push:
     branches-ignore:
     - gh-pages
-    - master
 
 # Left to-do:
-# - coverage
 # - publishing docs to gh-pages
 # - persistent artifact cache
 # - overnight jobs
@@ -43,16 +41,20 @@ jobs:
       fail-fast: false
       matrix:
 
-        # Main test targets, the name defines the image that will be used as
-        # the base for running tests.
-        test-name:
-          - debian:10
-          - fedora:31
-          - fedora:32
-          - ubuntu:18.04
-          - centos:7.7.1908
-
         include:
+          # Main test targets, the image-name defines the image that will be used as
+          # the base for running tests. `:` not allowed in github artifact names.
+          - test-name: test-debian-10
+            image-name: debian:10
+          - test-name: test-fedora-31
+            image-name: fedora:31
+          - test-name: test-fedora-32
+            image-name: fedora:32
+          - test-name: test-ubuntu-18.04
+            image-name: ubuntu:18.04
+          - test-name: test-centos-7.7
+            image-name: centos:7.7.1908
+
           # Ensure that tests also pass without `--develop` flag.
           - test-name: no-usedevelop
             image-name: fedora:32
@@ -109,14 +111,22 @@ jobs:
               --env PYTEST_ARGS \
               --env TOXENV=${{ matrix.toxenv || env.TOXENV }} \
               --env BST_PLUGINS_EXPERIMENTAL_VERSION=${{ matrix.bst-plugins-experimental-version || env.BST_PLUGINS_EXPERIMENTAL_VERSION }} \
+              --env COVERAGE_PREFIX=${{ matrix.test-name}} \
               --volume /home/runner/work:/__w \
               --workdir /__w/buildstream/buildstream \
               "$CI_IMAGE_PREFIX"-${{ matrix.image-name || matrix.test-name }}-"$CI_IMAGE_SUFFIX" \
               ./runtox.sh
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage-reports
+          path: .coverage-reports
+
   tests-fedora-missing-deps:
     runs-on: ubuntu-20.04
     container: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:32-master-177137613
+    if: github.ref != 'refs/heads/master'
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -140,6 +150,7 @@ jobs:
   mypy:
     runs-on: ubuntu-20.04
     container: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:32-master-177137613
+    if: github.ref != 'refs/heads/master'
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -149,6 +160,7 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     container: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:32-master-177137613
+    if: github.ref != 'refs/heads/master'
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -157,6 +169,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-20.04
+    if: github.ref != 'refs/heads/master'
     env:
       BST_FORCE_SESSION_REBUILD: 1
     steps:
@@ -182,3 +195,41 @@ jobs:
           name: docs
           path: doc/build/html
 
+  coverage:
+    runs-on: ubuntu-20.04
+    container: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:10-master-177137613
+    needs: tests
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        # BuildStream requires tags to be able to find its version.
+        with:
+          fetch-depth: 0
+      - name: Download cached coverage reports
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage-reports
+          path: .coverage-reports/
+      - name: Generate combined coverage report, install codecov deps
+        run: |
+          apt update && apt install -y curl
+          cp -a .coverage-reports/ ./coverage-sources
+          tox -e coverage
+          cp -a .coverage-reports/ ./coverage-report
+      - name: Upload final coverage artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: |
+            coverage-sources/
+            coverage-report/
+      - name: Delete intermediate job coverage artifacts
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: coverage-reports
+          failOnError: false
+      - name: codecov xml upload & master badge update
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage-report/coverage.xml
+          name: Coverage Report

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ About
 .. image:: https://gitlab.com/BuildStream/buildstream/badges/master/pipeline.svg
    :target: https://gitlab.com/BuildStream/buildstream/commits/master
 
-.. image:: https://gitlab.com/BuildStream/buildstream/badges/master/coverage.svg?job=coverage
-   :target: https://gitlab.com/BuildStream/buildstream/commits/master
+.. image:: https://codecov.io/gh/buildstream-migration/buildstream/branch/master/graph/badge.svg
+   :target: https://codecov.io/buildstream-migration/buildstream
 
 .. image:: https://img.shields.io/pypi/v/BuildStream.svg
    :target: https://pypi.org/project/BuildStream

--- a/tox.ini
+++ b/tox.ini
@@ -111,6 +111,7 @@ usedevelop = True
 commands =
     coverage combine --rcfile={toxinidir}/.coveragerc {toxinidir}/.coverage-reports/
     coverage html --rcfile={toxinidir}/.coveragerc --directory={toxinidir}/.coverage-reports/
+    coverage xml --rcfile={toxinidir}/.coveragerc -o {toxinidir}/.coverage-reports/coverage.xml
     coverage report --rcfile={toxinidir}/.coveragerc --show-missing
 deps =
     -rrequirements/cov-requirements.txt


### PR DESCRIPTION
As currently configured (With https://github.com/apps/codecov installed on the `buildstream-migration` org, with permission granted to this repo) **this will:**

- Comment with a codecov bot with a graph showing the +/- diff from coverage.py reports if a PR exists at  report upload time based on a branch from the main repo. This comment will be updated for any subsequent CI runs. `Checks` will also be added.
- Display `sunburst` graphs and historical commit info on https://codecov.io/gh/buildstream-migration/buildstream for branches which have had data uploaded
- Display a codecov badge for master in the README, replacing gitlabs builtin `coverage: '/TOTAL +\d+ +\d+ +(\d+\.\d+)%/'` 
output scraping and builtin magic
- Upload a combined zip file Github Artifact of the collated/combined coverage reports from the relative test runs, including the xml which is sent to Codecov
- Adds a `codecov.yml` configuration file to the global `.github/` ci path, allowing for project wide configuration. This is currently the default template with slight tweaks for gating.
- Run the required target tests on pushes to master (usually a PR merge), this is needed to generate the coverage artifacts for Codecov. Ultimately this is excessive however there is no builtin actions way to support sharing artifacts between workflows (the separate merge/pull_request workflow targeting pushes to master could just do the coverage collation/upload for previously run 'push' workflow artifacts)

**This will not:**
- Comment with a codecov bot if CI has already completed, before the PR has been opened. However the comment will be triggered if CI is reran for the PR, on a rebase/force push for example. Being able to share artifacts across different workflows (reports generated on generic `push` ci.yml) would enable for the coverage uploads to be only executed in a `pull_request` workflow, but as it stands Github Actions does not support this, and neither does the Github API. A workflow on `pull_request` could use https://github.com/actions/github-script to create a useful comment, potentially pulling in data from the codecov api if the report has already been uploaded to codecov on `push`. I've yet to find any API that will let you retrigger the codecov bot comment on demand which would be highly useful here.
- The coverage `Checks` are set to be non-gating so will show as passes regardless of % degradation. This threshold can be given a range and set to gated when desired
- As with many cases, the CodeCov integration will not work on PR's from forks (no access to secret tokens, no access from CodeCov to different name spaces). However if the committer has enabled actions in their fork then coverage report artifacts should still be viewable. 



An example of a PR can be seen here https://github.com/tom--pollard/buildstream/pull/3 
An example of the codecov page can be seen here https://codecov.io/gh/tom--pollard/buildstream
An example of the coverage artifact can be seen here https://github.com/tom--pollard/buildstream/suites/1368282522/artifacts/22392302

Apache seemingly have Codecov enabled on their Github Org, so adding the BuildStream repo to it should not be an infra/topical issue https://codecov.io/gh/apache