### PR TITLE
README.rst Add badges for latest release & semver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 About
 -----
 
-.. image:: https://buildstream.gitlab.io/buildstream/_static/release.svg
-   :target: https://gitlab.com/BuildStream/buildstream/commits/bst-1
+.. image:: https://img.shields.io/github/v/release/buildstream-migration/buildstream
+   :target: https://github.com/buildstream-migration/buildstream/releases/latest
 
-.. image:: https://buildstream.gitlab.io/buildstream/_static/snapshot.svg
-   :target: https://gitlab.com/BuildStream/buildstream/commits/master
+.. image:: https://img.shields.io/github/v/release/buildstream-migration/buildstream?color=orange&label=snapshot&sort=semver
+   :target: https://github.com/buildstream-migration/buildstream/releases
 
 .. image:: https://gitlab.com/BuildStream/buildstream/badges/master/pipeline.svg
    :target: https://gitlab.com/BuildStream/buildstream/commits/master


### PR DESCRIPTION
In Gitlab, the release/snapshot badges are created in repo when creating docs release, and hosted as static images on the gitlab.io docs site (and explictly added to the top repo overview with https://docs.gitlab.com/ee/user/project/badges.html):

https://github.com/buildstream-migration/buildstream/blob/master/doc/Makefile#L128
https://github.com/buildstream-migration/buildstream/blob/master/doc/badges.py

A PR to continue using the above is at https://github.com/buildstream-migration/buildstream/pull/11, however with the below we could maybe consider dropping the in-house badge generation and svg hosting

An example of the `release` badge:

![](https://img.shields.io/github/v/release/buildstream-migration/buildstream)

With a reStructuredText `:target:` to https://github.com/buildstream-migration/buildstream/releases/latest

I'm not sure if we want this tracking the `latest` release on Github, or specifically the latest 'stable' branch. 

The `snapshot` badge:

![](https://img.shields.io/github/v/release/buildstream-migration/buildstream?color=orange&label=snapshot&sort=semver)

With a reStructuredText `:target:` to https://github.com/buildstream-migration/buildstream/releases/

For some reason semver sorting is returning 1.93.1 and not 1.93.5, I'm not sure if this is a cache issue somewhere with github api/shields.io as we 'released' all the tags as a batch with the migration. However it may be something more problematic. However it might be resolved by enabling the following on the org/repo:

"If your GitHub badge errors, it might be because you hit GitHub's rate limits. You can increase Shields.io's rate limit by [adding the Shields GitHub application](https://img.shields.io/github-auth) using your GitHub account."