### PR TITLE
README.rst: Link release/snapshot badge to Github Pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 About
 -----
 
-.. image:: https://buildstream.gitlab.io/buildstream/_static/release.svg
-   :target: https://gitlab.com/BuildStream/buildstream/commits/bst-1
+.. image:: https://buildstream-migration.github.io/buildstream/_static/release.svg
+   :target: https://github.com/buildstream-migration/buildstream/commits/bst-1
 
-.. image:: https://buildstream.gitlab.io/buildstream/_static/snapshot.svg
-   :target: https://gitlab.com/BuildStream/buildstream/commits/master
+.. image:: https://buildstream-migration.github.io/buildstream/_static/snapshot.svg
+   :target: https://github.com/buildstream-migration/buildstream/commits/master
 
 .. image:: https://gitlab.com/BuildStream/buildstream/badges/master/pipeline.svg
    :target: https://gitlab.com/BuildStream/buildstream/commits/master


### PR DESCRIPTION
This is just ensuring/checking that we can still use our builtin/generated badges for releases/snapshots after the infra migration

An alternative proposal which could lead to dropping badges.py is at https://github.com/buildstream-migration/buildstream/pull/9